### PR TITLE
feat: add support for DFT reference in libscf CUHF

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1440,7 +1440,7 @@ def scf_wavefunction_factory(name, ref_wfn, reference, **kwargs):
         wfn = core.ROHF(ref_wfn, superfunc)
     elif reference in ["UHF", "UKS"]:
         wfn = core.UHF(ref_wfn, superfunc)
-    elif reference == "CUHF":
+    elif reference in ["CUHF", "CUKS"]:
         wfn = core.CUHF(ref_wfn, superfunc)
     else:
         raise ValidationError("SCF: Unknown reference (%s) when building the Wavefunction." % reference)

--- a/psi4/driver/procrouting/proc_util.py
+++ b/psi4/driver/procrouting/proc_util.py
@@ -60,7 +60,7 @@ def scf_set_reference_local(name, is_dft=False):
         elif (user_ref == 'ROHF'):
             raise ValidationError('ROHF reference for DFT is not available.')
         elif (user_ref == 'CUHF'):
-            raise ValidationError('CUHF reference for DFT is not available.')
+            core.set_local_option('SCF', 'REFERENCE', 'CUKS')
     # else we are doing HF and nothing needs to be overloaded
 
     return optstash

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -284,7 +284,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
         level_shift_enabled = core.get_option("SCF", "LEVEL_SHIFT") != 0.0
         autograc_enabled = core.get_option("SAPT", "SAPT_DFT_GRAC_COMPUTE") != "NONE"
         guessmix_enabled = core.get_option("SCF", "GUESS_MIX")
-        if (reference in ["ROHF", "CUHF"] or soscf_enabled or self.MOM_excited_ or frac_enabled or
+        if (reference in ["ROHF", "CUHF", "CUKS"] or soscf_enabled or self.MOM_excited_ or frac_enabled or
             efp_enabled or pcm_enabled or ddx_enabled or pe_enabled or autograc_enabled or
             level_shift_enabled or guessmix_enabled):
             core.print_out(f"    Note: OpenOrbitalOptimizer not compatible with at least one of the following. Falling back to orbital_optimizer_package=internal\n")

--- a/psi4/src/psi4/libscf_solver/cuhf.h
+++ b/psi4/src/psi4/libscf_solver/cuhf.h
@@ -31,6 +31,7 @@
 
 #include "hf.h"
 #include "psi4/libpsio/psio.hpp"
+#include "psi4/libfock/v.h"
 
 namespace psi {
 class VBase;
@@ -73,12 +74,16 @@ class CUHF final : public HF {
     SharedMatrix Dt_, Dt_old_;
     SharedMatrix Da_old_, Db_old_;
     SharedMatrix J_, Ka_, Kb_;
+    // Long-range exchange matrices for range-separated functionals
+    SharedMatrix wKa_, wKb_;
     // Contributions to the Fock matrix from charge and spin density
     SharedMatrix Fp_, Fm_;
     // Charge density and natural orbitals (eigenvectors of charge density)
     SharedMatrix Dp_, Cno_, Cno_temp_;
     // Natural orbital occupations
     SharedVector No_;
+    // DFT potential object for XC contributions
+    std::shared_ptr<UV> potential_;
 
     void form_initial_F() override;
     double compute_initial_E() override;
@@ -87,6 +92,7 @@ class CUHF final : public HF {
 
     void common_init();
     void setup_potential() override;
+    void form_V() override;
 
    public:
     CUHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional);
@@ -106,7 +112,7 @@ class CUHF final : public HF {
     void damping_update(double) override;
     bool stability_analysis() override;
 
-    std::shared_ptr<VBase> V_potential() const override { return nullptr; };
+    std::shared_ptr<VBase> V_potential() const override { return potential_; };
 
     std::shared_ptr<CUHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 

--- a/psi4/src/psi4/libscf_solver/frac.cc
+++ b/psi4/src/psi4/libscf_solver/frac.cc
@@ -211,7 +211,7 @@ void HF::frac_helper() {
 
 void HF::compute_spin_contamination() {
     if (!(options_.get_str("REFERENCE") == "UHF" || options_.get_str("REFERENCE") == "UKS" ||
-          options_.get_str("REFERENCE") == "CUHF"))
+          options_.get_str("REFERENCE") == "CUHF" || options_.get_str("REFERENCE") == "CUKS"))
         return;
 
     auto nalpha = (double)nalpha_;
@@ -270,6 +270,10 @@ void HF::compute_spin_contamination() {
     outfile->Printf("   @S^2 Observed:              %17.9E\n", S2 + dS);
     outfile->Printf("   @S   Expected:              %17.9E\n", nm);
     outfile->Printf("   @S   Observed:              %17.9E\n", nm);
+
+    set_scalar_variable("SCF S2 OBSERVED", S2 + dS);
+    set_scalar_variable("SCF S2 EXPECTED", S2);
+    set_scalar_variable("SCF SPIN CONTAMINATION METRIC", dS);
 
     if (frac_performed_) {
         outfile->Printf("   @Nalpha:                    %17.9E\n", nalpha);

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -877,7 +877,7 @@ void HF::print_orbitals() {
         print_orbital_pairs("Doubly Occupied:", occ);
         print_orbital_pairs("Virtual:", vir);
 
-    } else if ((reference == "UHF") || (reference == "UKS") || (reference == "CUHF")) {
+    } else if ((reference == "UHF") || (reference == "UKS") || (reference == "CUHF") || (reference == "CUKS")) {
         std::vector<std::pair<double, std::pair<std::string, int> > > occA;
         std::vector<std::pair<double, std::pair<std::string, int> > > virA;
         std::vector<std::pair<double, std::pair<std::string, int> > > occB;

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1462,7 +1462,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("WFN", "SCF", "SCF");
         /*- Reference wavefunction type.
         **Cfour Interface:** Keyword translates into |cfour__cfour_reference|. -*/
-        options.add_str("REFERENCE", "RHF", "RHF ROHF UHF CUHF RKS UKS");
+        options.add_str("REFERENCE", "RHF", "RHF ROHF UHF CUHF RKS UKS CUKS");
         /*- Primary basis set -*/
         options.add_str("BASIS", "");
         /*- Auxiliary basis set for SCF density fitting computations.

--- a/pytest.ini
+++ b/pytest.ini
@@ -39,6 +39,7 @@ markers =
     ci
     cisd
     cubeprop
+    cuks
     d2ints: "tests that fail when 2nd derivative ERI missing from Libint2, either because dertype 2 demanded or tested too tightly for 3-pt FD."
     dct
     # ddd: "findif and cbs and nbody" (not defined, so use equiv. expansion)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,7 +54,7 @@ foreach(test_name aediis-1
                   dft-grad-lr1 dft-grad-lr2 dft-grad-lr3 dft-grad-disk
                   dfomp2p5-grad2 dfrasscf-sp dfscf-bz2 dft-b2plyp dft-grac dft-ghost dft-grad-meta
                   dft-freq dft-freq-analytic1 dft-freq-analytic2 dft-grad1 dft-grad2 dft-psivar dft-b3lyp dft1 dft-vv10
-                  dft1-alt dft2 dft3 dft-omega dft-dens-cut dlpnocc-1 dlpnocc-2 dlpnocc-3 dlpnocc-4 dlpnomp2-1 dlpnomp2-2 
+                  dft1-alt dft2 dft3 dft-omega dft-dens-cut cuks1 dlpnocc-1 dlpnocc-2 dlpnocc-3 dlpnocc-4 dlpnomp2-1 dlpnomp2-2
                   dlpnomp2-3 docs-bases docs-dft embpot1 explicit-am-basis extern1 extern2 extern3 extern4 extern5
                   fsapt1 fsapt2 fsapt-terms fsapt-allterms fsapt-ext fsapt-ext-abc fsapt-ext-abc2
                   fsapt-ext-abc-au isapt1 isapt2 isapt-siao1 fisapt-siao1 isapt-charged

--- a/tests/cuks1/CMakeLists.txt
+++ b/tests/cuks1/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(cuks1 "psi;dft;scf;cuks")

--- a/tests/cuks1/input.dat
+++ b/tests/cuks1/input.dat
@@ -1,0 +1,63 @@
+#! CUKS (Constrained Unrestricted Kohn-Sham) Test
+#! Tests CUKS on CN-H2 dimer from O24 dataset (system 17)
+#! CN radical (doublet, S=1/2) has known high spin contamination
+#! Expected S^2 = 0.75 for doublet; UHF/UKS will show S^2 >> 0.75
+
+molecule cn_h2 {
+    0 2
+    C        -1.772500000    -0.607751490     0.000000000
+    N        -1.772500000     0.562848510     0.000000000
+    --
+    0 1
+    H         1.772500000    -0.022451490     0.371400000
+    H         1.772500000    -0.022451490    -0.371400000
+    units angstrom
+}
+
+set {
+    basis cc-pvdz
+    scf_type df
+    e_convergence 1.e-8
+    d_convergence 1.e-8
+}
+
+# uhf
+set reference uhf
+E_uhf, wfn_uhf = energy('hf', return_wfn=True)
+S2_uhf = wfn_uhf.variable("SCF S2 OBSERVED")
+
+# cuhf
+set reference cuhf
+E_cuhf, wfn_cuhf = energy('hf', return_wfn=True)
+S2_cuhf = wfn_cuhf.variable("SCF S2 OBSERVED")
+
+# uks
+set reference uks
+E_uks, wfn_uks = energy('b3lyp', return_wfn=True)
+S2_uks = wfn_uks.variable("SCF S2 OBSERVED")
+
+# cuks
+set reference cuks
+E_cuks, wfn_cuks = energy('b3lyp', return_wfn=True)
+S2_cuks = wfn_cuks.variable("SCF S2 OBSERVED")
+
+S2_expected = 0.75  # Doublet: S=1/2, S^2 = S(S+1) = 0.75
+S2_uhf_contamination = 0.39622127
+S2_uks_contamination = 0.00720174
+
+print(f'\n  CN-H2 Dimer (doublet, expected S^2 = {S2_expected})')
+print(f'\n  HF Methods:')
+print(f'    UHF:   E = {E_uhf:16.10f} Eh,  S^2 = {S2_uhf:.5f}  (contamination: {S2_uhf - S2_expected:+.5f})')
+print(f'    CUHF:  E = {E_cuhf:16.10f} Eh,  S^2 = {S2_cuhf:.5f}  (contamination: {S2_cuhf - S2_expected:+.5f})')
+print(f'    dE = {(E_cuhf - E_uhf)*1000:8.4f} mEh')
+print(f'\n  DFT Methods (B3LYP):')
+print(f'    UKS:   E = {E_uks:16.10f} Eh,  S^2 = {S2_uks:.5f}  (contamination: {S2_uks - S2_expected:+.5f})')
+print(f'    CUKS:  E = {E_cuks:16.10f} Eh,  S^2 = {S2_cuks:.5f}  (contamination: {S2_cuks - S2_expected:+.5f})')
+print(f'    dE = {(E_cuks - E_uks)*1000:8.4f} mEh')
+
+# === Validation ===
+print('\n  ====== Validation ======')
+compare_values(S2_expected, S2_cuhf, 5, "CUHF S^2 should be exact")  #TEST
+compare_values(S2_expected, S2_cuks, 5, "CUKS S^2 should be exact")  #TEST
+compare_values(S2_expected, S2_uhf - S2_uhf_contamination, "Spin contamination was expected in UHF", atol=1e-6)  #TEST
+compare_values(S2_expected, S2_uks - S2_uks_contamination, "Spin contamination was expected in UKS", atol=1e-6)  #TEST

--- a/tests/cuks1/test_input.py
+++ b/tests/cuks1/test_input.py
@@ -1,0 +1,5 @@
+from addons import *
+
+@ctest_labeler("dft;scf;cuks")
+def test_cuks1():
+    ctest_runner(__file__)


### PR DESCRIPTION
## Description
Adds DFT codepath support in cuhf.cc

## User API & Changelog headlines
- [ ] adds 3 new variables accessible post SCF: `SCF S2 OBSERVED`, `SCF S2 EXPECTED`, and `SCF SPIN CONTAMINATION METRIC` for UHF/CUHF/UKS/CUKS.

## Dev notes & details
Adds DFT machinery to cuhf.cc based on what uhf.cc already had.
I've added CUKS to opt out for external orbital optimization in scf_iterator.py, since AFAIK orbital Hessians were not derived for constrained UHF/UKS.
ref: https://pubs.aip.org/aip/jcp/article/133/14/141102/350937/Communication-ROHF-theory-made-simple 

## Questions
- When running the full test suite locally, I've stumbled upon a DLPNO-CCSD(T) convergence issue. I don't know if that shows up in CI, but that test might be flaky. Local machine is AMD's Strix Point APU - AMD Ryzen AI 9 HX PRO 370. I've posted details below.

- Should I add some more tests with a wider range of functionals? Investigation for usability of CUKS for SAPT references is underway; after that work is done, I might have some insights about what should be tested. Currently added tests are more of a smoke/sanity check, that the CUHF codepath is not borked, and CUKS produce sensible results.

```log
...
========================================================================================================== short test summary info ===========================================================================================================
FAILED dlpnocc-4/test_input.py::test_dlpnocc_4 - AssertionError:    Testing DLPNO-CCSD(T) loose...
============================================================================= 1 failed, 6572 passed, 1510 skipped, 51 xfailed, 12 warnings in 3594.41s (0:59:54) =============================================================================
...
E       !----------------------------------------------------------------------------------!
E       !                                                                                  !
E       !         ccsd corl: computed value (-1.582425386) does not match (-1.582425532)   !
E       !     to atol=1e-07 by difference (0.000000146).                                   !
E       !                                                                                  !
E       !----------------------------------------------------------------------------------!
...

```

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
